### PR TITLE
Have `PhantomJSEnv(...).value` take a `PhantomJSEnv.Config`.

### DIFF
--- a/phantomjs-sbt-plugin/src/main/scala/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin.scala
+++ b/phantomjs-sbt-plugin/src/main/scala/org/scalajs/jsenv/phantomjs/sbtplugin/PhantomJSEnvPlugin.scala
@@ -25,7 +25,7 @@ import org.scalajs.jsenv.phantomjs._
  *  is automatically triggered by Scala.js projects.
  *
  *  Usually, one only needs to use the
- *  [[PhantomJSEnvPlugin.autoImport.PhantomJSEnv]] method.
+ *  [[PhantomJSEnvPlugin.autoImport PhantomJSEnv]] method.
  */
 object PhantomJSEnvPlugin extends AutoPlugin {
   override def requires: Plugins = ScalaJSPlugin
@@ -46,14 +46,17 @@ object PhantomJSEnvPlugin extends AutoPlugin {
           KeyRanks.Invisible)
     }
 
-    /** An [[sbt.Def.Initialize Def.Initialize]] for a [[PhantomJSEnv]].
+    /** An [[sbt.Def.Initialize Def.Initialize]] for a `PhantomJSEnv`.
      *
      *  Use this to specify in your build that you would like to run and/or
      *  test a project with PhantomJS:
      *
      *  {{{
-     *  jsEnv := PhantomJSEnv().value
+     *  jsEnv := PhantomJSEnv(...).value
      *  }}}
+     *
+     *  The specified `Config` is augmented with an appropriate Jetty class
+     *  loader (through `withJettyClassLoader`).
      *
      *  Note that the resulting [[sbt.Def.Setting Setting]] is not scoped at
      *  all, but must be scoped in a project that has the ScalaJSPlugin enabled
@@ -63,20 +66,22 @@ object PhantomJSEnvPlugin extends AutoPlugin {
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
     def PhantomJSEnv(
-        executable: String = "phantomjs",
-        args: Seq[String] = Seq.empty,
-        env: Map[String, String] = Map.empty,
-        autoExit: Boolean = true
+        config: org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config
     ): Def.Initialize[Task[PhantomJSEnv]] = Def.task {
       val loader = scalaJSPhantomJSClassLoader.value
-      new PhantomJSEnv(
-          org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config()
-            .withExecutable(executable)
-            .withArgs(args.toList)
-            .withEnv(env)
-            .withAutoExit(autoExit)
-            .withJettyClassLoader(loader))
+      new PhantomJSEnv(config.withJettyClassLoader(loader))
     }
+
+    /** An [[sbt.Def.Initialize Def.Initialize]] for a `PhantomJSEnv` with the
+     *  default configuration.
+     *
+     *  This is equivalent to
+     *  {{{
+     *  PhantomJSEnv(org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config())
+     *  }}}
+     */
+    def PhantomJSEnv(): Def.Initialize[Task[PhantomJSEnv]] =
+      PhantomJSEnv(org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config())
   }
 
   import autoImport._

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -10,6 +10,11 @@ lazy val jetty9 = project.
   settings(
     name := "Scala.js sbt test with jetty9 on classpath",
     // Use PhantomJS, allow cross domain requests
-    jsEnv := PhantomJSEnv(args = Seq("--web-security=no")).value,
+    jsEnv := {
+      PhantomJSEnv(
+          org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config()
+            .withArgs(List("--web-security=no"))
+      ).value
+    },
     Jetty9Test.runSetting
   )


### PR DESCRIPTION
This is a forward port of the non-deprecated parts of https://github.com/scala-js/scala-js/pull/3099.