### PR TITLE
Ignore the test `syntaxErrorTest`, since it is broken on master.

### DIFF
--- a/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/PhantomJSTest.scala
+++ b/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/PhantomJSTest.scala
@@ -2,6 +2,14 @@ package org.scalajs.jsenv.phantomjs
 
 import org.scalajs.jsenv.test._
 
+import org.junit.{Ignore, Test}
+
 class PhantomJSTest extends JSEnvTest with ComTests {
   protected def newJSEnv: PhantomJSEnv = new PhantomJSEnv
+
+  // Disabled du to #10
+  @Test
+  @Ignore
+  override def syntaxErrorTest: Unit =
+    super.syntaxErrorTest
 }


### PR DESCRIPTION
PhantomJS 2.0.0 seems to have broken that test. We ignore it until we find a fix. The bug is filed as #10.