### PR TITLE
Disable coursier because it breaks the sbt-plugin-test with 0.13.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ jdk:
   - openjdk8
 install:
   - if [[ "${TRAVIS_SCALA_VERSION}" == "2.10.7" ]]; then TEST_SBT_VERSION=0.13.17; elif [[ "${TRAVIS_SCALA_VERSION}" == "2.12.8" ]]; then TEST_SBT_VERSION=1.2.8; else TEST_SBT_VERSION=false; fi
-  # The default ivy resolution takes way too much time, and times out Travis builds.
-  # We use coursier instead.
-  - mkdir -p $HOME/.sbt/0.13/plugins/
-  - echo 'addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")' > $HOME/.sbt/0.13/plugins/coursier.sbt
-  - mkdir -p $HOME/.sbt/1.0/plugins/
-  - echo 'addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")' > $HOME/.sbt/1.0/plugins/coursier.sbt
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalajs-env-phantomjs/test scalajs-env-phantomjs/doc
   - |
@@ -28,9 +22,6 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - $HOME/.coursier/cache
 before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt -name "*.lock" -print -delete
-  - rm $HOME/.sbt/0.13/plugins/coursier.sbt
-  - rm $HOME/.sbt/1.0/plugins/coursier.sbt


### PR DESCRIPTION
There's a failure on Travis for master now, see https://travis-ci.org/scala-js/scala-js-env-phantomjs/jobs/540462693. Experiments suggest that coursier is responsible. It probably did not happen in the CI for the PR because of previous caches on Travis.

Before submitting this PR and hence running the CI, I have cleared all the caches on Travis.